### PR TITLE
feat(): DicomFile.js - parse SeriesDescription tag on DICOM files wit…

### DIFF
--- a/src/model/DicomFile.js
+++ b/src/model/DicomFile.js
@@ -200,6 +200,9 @@ export default class DicomFile {
         case "x0020000e":
           resultMap.set("SeriesInstanceUID", this._getString(element));
           break;
+        case "x0008103e":
+          resultMap.set("SeriesDescription", this._getString(element));
+          break;
       }
     }
   }


### PR DESCRIPTION
…h other modalities to show it in the UI

We just use the SeriesDescription for the UI. SeriesTime and SeriesDate are not shown. That's why the pull request is limited to the Description. The StudyDate itsel is already parsed and part of the UI.