### PR TITLE
feat: DeIdentificationConfiguration - KP action only adds a prefix if…

### DIFF
--- a/src/util/deidentification/DeIdentificationConfiguration.js
+++ b/src/util/deidentification/DeIdentificationConfiguration.js
@@ -247,19 +247,22 @@ export default class DeIdentificationConfiguration {
    * Implementation of the function for action code KP
    */
   keepAndAddPrefix(dictionary, propertyName, prefix) {
-    const originalElementValue = dictionary[propertyName].Value;
-    if (Array.isArray(originalElementValue)) {
-      const newElementValue = [];
-      if (originalElementValue.length > 0) {
-        for (let el of originalElementValue) {
-          newElementValue.push("(" + prefix + ")-" + el);
-        }
-      } else {
-        // do nothing
-      }
-      dictionary[propertyName].Value = newElementValue;
+    let elementValue = dictionary[propertyName].Value;
+    if (Array.isArray(elementValue)) {
+      // prefix first element if necessary
+      elementValue[0] = this.ensureOnePrefix(elementValue[0], prefix);
     } else {
-      dictionary[propertyName].Value = "(" + prefix + ")-" + originalElementValue;
+      // no array -  prefix String if necessary
+      elementValue = this.ensureOnePrefix(elementValue, prefix);
+    }
+    dictionary[propertyName].Value = elementValue;
+  }
+
+  ensureOnePrefix(value, prefix) {
+    if (value.startsWith("(" + prefix + ")-")) {
+      return value;
+    } else {
+      return "(" + prefix + ")-" + value;
     }
   }
 

--- a/test/unit/util/deidentification/DeIdentificationConfiguration.test.js
+++ b/test/unit/util/deidentification/DeIdentificationConfiguration.test.js
@@ -789,8 +789,31 @@ describe("DeIdentificationConfiguration Tests", () => {
       expect(dataSetDictionary[tag].Value).toBe("(" + parameter + ")-" + originalValue);
     });
 
+    test("Does not add a prefix to the the original String value if it already has the same prefix.", () => {
+      const originalValue = "originalValue";
+      const dataSetDictionary = {};
+      const prefix = "(" + uploadSlot.studyEdcCode + ")-";
+
+      const element = {
+        Value: prefix + originalValue,
+      };
+      const tag = "00081030";
+      const vr = "dummy";
+      dataSetDictionary[tag] = element;
+
+      const deIdentificationProfileOption = [DeIdentificationProfiles.BASIC, DeIdentificationProfiles.RPB_PROFILE];
+      const factory = new DeIdentificationConfigurationFactory({ deIdentificationProfileOption }, uploadSlot);
+      const configuration = factory.getConfiguration();
+      let { action, parameter } = configuration.getTask(tag, vr);
+
+      action(dataSetDictionary, tag, parameter);
+
+      expect(dataSetDictionary[tag].Value).toBe(prefix + originalValue);
+    });
+
     test("Adds a prefix to the the original String value in an Array.", () => {
-      const originalValue = ["originalValue"];
+      const originalString = "originalValue";
+      const originalValue = [originalString];
       const dataSetDictionary = {};
 
       const element = {
@@ -807,7 +830,30 @@ describe("DeIdentificationConfiguration Tests", () => {
 
       action(dataSetDictionary, tag, parameter);
 
-      expect(dataSetDictionary[tag].Value).toStrictEqual(["(" + parameter + ")-" + originalValue]);
+      expect(dataSetDictionary[tag].Value).toStrictEqual(["(" + parameter + ")-" + originalString]);
+    });
+
+    test("Does not add a prefix to the the original String value in an Array if it already starts with the same prefix.", () => {
+      const prefix = "(" + uploadSlot.studyEdcCode + ")-";
+      const originalString = "originalValue";
+      const originalValue = [prefix + originalString, "dummyString"];
+      const dataSetDictionary = {};
+
+      const element = {
+        Value: originalValue,
+      };
+      const tag = "00081030";
+      const vr = "dummy";
+      dataSetDictionary[tag] = element;
+
+      const deIdentificationProfileOption = [DeIdentificationProfiles.BASIC, DeIdentificationProfiles.RPB_PROFILE];
+      const factory = new DeIdentificationConfigurationFactory({ deIdentificationProfileOption }, uploadSlot);
+      const configuration = factory.getConfiguration();
+      let { action, parameter } = configuration.getTask(tag, vr);
+
+      action(dataSetDictionary, tag, parameter);
+
+      expect(dataSetDictionary[tag].Value).toStrictEqual([prefix + originalString, "dummyString"]);
     });
 
     // keep


### PR DESCRIPTION
… the value is not prefixed already