### PR TITLE
fix: On updateDicomUploadPackage - the VirtualSeriesObject is picked …

### DIFF
--- a/src/uploader/Uploader.js
+++ b/src/uploader/Uploader.js
@@ -656,7 +656,7 @@ class Uploader extends Component {
         const originalSeries = selectedStudyAllSeriesMap[originalSeriesInstanceUID];
         const instances = originalSeries.getInstancesByUIDArray(virtualNode.sopInstancesUIDs);
 
-        let virtualSeriesObject = selectedSeriesObjects[uid];
+        let virtualSeriesObject = selectedSeriesObjects[originalSeriesInstanceUID];
 
         if (virtualSeriesObject === undefined) {
           const newVirtualSeriesObject = Object.create(Object.getPrototypeOf(originalSeries));


### PR DESCRIPTION
…with the original SeriesInstanceUID. Before, it tried to pick the object by using the SeriesInstanceUID that is specific for the virtual Series. That would not find anything, because at this step, we need to sum up the instances of all selected virtual series (that are split from one DicomSeries) .