### PR TITLE
feat: propagating error message from DCMJS parsing to the UI

### DIFF
--- a/src/model/DicomFile.js
+++ b/src/model/DicomFile.js
@@ -127,9 +127,11 @@ export default class DicomFile {
       dcmjsResult = DicomMessage.readFile(arrayBuffer);
       if (dcmjsResult != undefined) {
         this.parsable = true;
+        this.parsingMessage = "";
       }
     } catch (error) {
       this.parsable = false;
+      this.parsingMessage = error.message;
     }
   }
 
@@ -849,6 +851,7 @@ export default class DicomFile {
       referencedSopInstanceUids: this.referencedSopInstanceUids,
       description: this.getSeriesDescription(),
       parsable: this.parsable,
+      parsingMessage: this.parsingMessage,
       parsedParameters: this.parsedParameters,
     };
 

--- a/src/model/DicomFile.js
+++ b/src/model/DicomFile.js
@@ -33,8 +33,9 @@ import DicomStudy from "./DicomStudy";
 export default class DicomFile {
   dicomDirSopValues = ["1.2.840.10008.1.3.10"];
 
-  constructor(fileObject) {
+  constructor(fileObject, log) {
     this.fileObject = fileObject;
+    this.log = log;
   }
 
   __pFileReader(file) {
@@ -132,6 +133,11 @@ export default class DicomFile {
     } catch (error) {
       this.parsable = false;
       this.parsingMessage = error.message;
+      this.log.trace(
+        "File parsing with DCMJS failed",
+        { fileName: this.fileObject.name },
+        { errorMessage: error.message }
+      );
     }
   }
 

--- a/src/model/DicomInstance.js
+++ b/src/model/DicomInstance.js
@@ -29,6 +29,7 @@ export default class DicomInstance {
     this.referencedSopInstanceUids = fileObjectDetails.referencedSopInstanceUids;
     this.description = fileObjectDetails.description;
     this.parsable = fileObjectDetails.parsable;
+    this.parsingMessage = fileObjectDetails.parsingMessage;
     this.parsedParameters = fileObjectDetails.parsedParameters;
   }
 

--- a/src/model/DicomSeries.js
+++ b/src/model/DicomSeries.js
@@ -209,12 +209,12 @@ export default class DicomSeries {
   /**
    * Returns an array with the file names if some files cannot be parsed properly by the DICOM tool (dcmjs).
    */
-  getNotParsableFileNames() {
+  getNotParsableFileDetails() {
     const fileNames = [];
     for (let instanceUID of this.instances.keys()) {
       const instanceObject = this.instances.get(instanceUID);
       if (!instanceObject.parsable) {
-        fileNames.push(instanceObject.fileObject.name);
+        fileNames.push(instanceObject.fileObject.name + " - " + instanceObject.parsingMessage);
       }
     }
     return fileNames;

--- a/src/uploader/DicomParsingMenu.js
+++ b/src/uploader/DicomParsingMenu.js
@@ -141,6 +141,14 @@ export default class DicomParsingMenu extends Component {
                 }
               />
               <StyledButton
+                label="Log file"
+                onClick={this.props.generateLogFile}
+                icon="pi pi-file"
+                iconPos="right"
+                className="p-button-warning"
+                hidden={this.props.selectedFilesCanBeParsed}
+              />
+              <StyledButton
                 label="Upload"
                 disabled={Object.keys(this.props.selectedNodeKeys).length === 0 || !this.props.selectedFilesCanBeParsed}
                 onClick={this.props.submitUploadPackage}

--- a/src/uploader/TreeSelection.js
+++ b/src/uploader/TreeSelection.js
@@ -158,11 +158,6 @@ export class TreeSelection extends Component {
 
     const seriesUid = node.data.seriesInstanceUID;
 
-    let fileList = [];
-    if (node.getNotParsableFileDetails.length > 0) {
-      fileList = node.getNotParsableFileDetails.map((item, index) => <div key={key + index}>{item}</div>);
-    }
-
     const sanityCheckResults = this.props.sanityCheckResultsPerSeries.get(seriesUid);
     const sanityCheckDetailList = sanityCheckResults.map((item, index) => (
       <div key={key + index}>
@@ -221,8 +216,8 @@ export class TreeSelection extends Component {
             >
               {node.parsable === true ? null : (
                 <Card title="DICOM File Parsing" className="text-pink-600">
-                  There is a problem parsing one or more files from the dataset:
-                  {fileList}
+                  There is a problem parsing one or more files with dcmjs. It is likely that your data set violates some
+                  DICOM standards. Please consider using tools like "dcmodify" from DCMTK to correct the data set.
                 </Card>
               )}
               {sanityCheckResults.length === 0 ? null : (

--- a/src/uploader/TreeSelection.js
+++ b/src/uploader/TreeSelection.js
@@ -159,8 +159,8 @@ export class TreeSelection extends Component {
     const seriesUid = node.data.seriesInstanceUID;
 
     let fileList = [];
-    if (node.notParsableFileNames.length > 0) {
-      fileList = node.notParsableFileNames.map((item, index) => <div key={key + index}>{item}</div>);
+    if (node.getNotParsableFileDetails.length > 0) {
+      fileList = node.getNotParsableFileDetails.map((item, index) => <div key={key + index}>{item}</div>);
     }
 
     const sanityCheckResults = this.props.sanityCheckResultsPerSeries.get(seriesUid);

--- a/src/uploader/Uploader.js
+++ b/src/uploader/Uploader.js
@@ -1054,7 +1054,7 @@ class Uploader extends Component {
    * @param {File} file
    */
   read = async (file) => {
-    const dicomFile = new DicomFile(file);
+    const dicomFile = new DicomFile(file, this.log);
     try {
       if (!file.path.endsWith(".dcm")) {
         if (file.path.endsWith(".gz") || file.path.endsWith(".zip")) {
@@ -1209,6 +1209,7 @@ class Uploader extends Component {
             ignoredFilesDetails={this.state.ignoredFilesDetails}
             sanityCheckResults={this.state.sanityCheckResults}
             selectedFilesCanBeParsed={this.state.selectedFilesCanBeParsed}
+            generateLogFile={this.generateLogFile}
             sanityCheckConfiguration={this.state.sanityCheckConfiguration}
             deIdentificationCheckResults={this.state.deIdentificationCheckResults}
             deIdentificationCheckResultsPerSeries={this.state.deIdentificationCheckResultsPerSeries}

--- a/src/util/treeHelper/TreeNodeFactory.js
+++ b/src/util/treeHelper/TreeNodeFactory.js
@@ -52,9 +52,9 @@ export default class TreeNodeFactory {
     treeNode.parsable = dicomSeries.getIsParsableState();
 
     if (treeNode.parsable) {
-      treeNode.notParsableFileNames = [];
+      treeNode.getNotParsableFileDetails = [];
     } else {
-      treeNode.notParsableFileNames = dicomSeries.getNotParsableFileNames();
+      treeNode.getNotParsableFileDetails = dicomSeries.getNotParsableFileDetails();
     }
     treeNode.instances = dicomSeries.instances;
   }


### PR DESCRIPTION
With this change, we extend the error message that is now presented to the user if the parsing fails by the actual error message of the DCMJS library together with the file name. With that change, it can be sorted out which file causes which issue if they are different.
